### PR TITLE
fix: mount  /dev to docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the directory where you run the command.*
 
 ```bash
 docker pull linkacloud/d2vm:latest
-alias d2vm="docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged -v \$PWD:/d2vm -w /d2vm linkacloud/d2vm:latest"
+alias d2vm="docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged -v \$(pwd):/d2vm -v /dev:/dev -w /d2vm linkacloud/d2vm:latest"
 ```
 
 ```bash

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -137,6 +137,8 @@ func RunD2VM(ctx context.Context, image, version, in, out, cmd string, args ...s
 		fmt.Sprintf("%s:/in", in),
 		"-v",
 		fmt.Sprintf("%s:/out", out),
+		"-v",
+		"/dev:/dev",
 		"-w",
 		"/d2vm",
 		fmt.Sprintf("%s:%s", image, version),


### PR DESCRIPTION
the docker image needs to have the /dev mounted in order to properly format the disk.

Updated both the `RunD2VM` and the README instructions to reflect this

closes #18