### PR TITLE
bugfix: use NetworkManager for ubuntu netplan

### DIFF
--- a/templates/ubuntu.Dockerfile
+++ b/templates/ubuntu.Dockerfile
@@ -32,18 +32,11 @@ RUN systemctl preset-all
 {{ if eq .NetworkManager "netplan" }}
 RUN apt install -y netplan.io
 RUN mkdir -p /etc/netplan && printf '\
+# Let NetworkManager manage all devices on this system\n\
 network:\n\
   version: 2\n\
-  renderer: networkd\n\
-  ethernets:\n\
-    eth0:\n\
-      dhcp4: true\n\
-      dhcp-identifier: mac\n\
-      nameservers:\n\
-        addresses:\n\
-        - 8.8.8.8\n\
-        - 8.8.4.4\n\
-' > /etc/netplan/00-netcfg.yaml
+  renderer: NetworkManager\n\
+' > /etc/netplan/01-network-manager-all.yaml
 {{ else if eq .NetworkManager "ifupdown"}}
 RUN if [ -z "$(apt-cache madison ifupdown-ng 2> /dev/nul)" ]; then apt install -y ifupdown; else apt install -y ifupdown-ng; fi
 RUN mkdir -p /etc/network && printf '\


### PR DESCRIPTION
The template config was hardcoded to eth0 and google dns.
This pr changes to `NetworkManager` instead, which is the default on Ubuntu 20.04 and 22.04.

NOTE: I'm not sure if we should change debian as well, I tried with debian12 and it seems like `network-manager` isn't installed by default, and `NetworkManager.service` was not loaded.