### PR TITLE
Update format validator to permit vhd and vhdx, update conversion logic to treat `.vhd` files as qemu-img vpc type

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -44,7 +44,7 @@ ff02::3 ip6-allhosts
 	perm os.FileMode = 0644
 )
 
-var formats = []string{"qcow2", "qed", "raw", "vdi", "vhd", "vmdk"}
+var formats = []string{"qcow2", "qed", "raw", "vdi", "vhdx", "vhd", "vmdk"}
 
 type Builder interface {
 	Build(ctx context.Context) (err error)

--- a/convert.go
+++ b/convert.go
@@ -87,6 +87,8 @@ func Convert(ctx context.Context, img string, opts ...ConvertOption) error {
 	format := strings.TrimPrefix(filepath.Ext(o.output), ".")
 	if format == "" {
 		format = "raw"
+	} else if format == "vhd" {
+		format = "vpc"
 	}
 	b, err := NewBuilder(ctx, tmpPath, imgUUID, "", o.size, r, format, o.cmdLineExtra, o.splitBoot, o.bootFS, o.bootSize, o.luksPassword, o.bootLoader, o.platform)
 	if err != nil {


### PR DESCRIPTION
Referencing [this issue](https://github.com/linka-cloud/d2vm/issues/47), this correction enables output to legacy `.vhd` and the new(er?) `.vhdx` formats.

Changes were tested by building two VM images: One adopting `.vhd` and the other `.vhdx`.  Both images were bootable under Hyper-V as well as an ESXi 6.5 box (after converting to VMDK and importiing with ESX' CLI)