### PR TITLE
support ubuntu12

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -280,6 +280,13 @@ func (b *builder) makeImg(ctx context.Context) error {
 }
 
 func (b *builder) mountImg(ctx context.Context) error {
+	var mkfsExt4Opts []string
+	r := ctx.Value("release").(OSRelease)
+	if r.ID == ReleaseUbuntu {
+		if strings.HasPrefix(r.VersionID, "12.") {
+			mkfsExt4Opts = append(mkfsExt4Opts, "-O", "^has_journal")
+		}
+	}
 	logrus.Infof("mounting raw image")
 	o, _, err := exec.RunOut(ctx, "losetup", "--show", "-f", b.diskRaw)
 	if err != nil {
@@ -315,7 +322,7 @@ func (b *builder) mountImg(ctx context.Context) error {
 		b.rootPart = "/dev/mapper/root"
 		b.mappedCryptRoot = filepath.Join("/dev/mapper", b.cryptRoot)
 		logrus.Infof("creating raw image file system")
-		if err := exec.Run(ctx, "mkfs.ext4", b.mappedCryptRoot); err != nil {
+		if err := exec.Run(ctx, "mkfs.ext4", append(mkfsExt4Opts, b.mappedCryptRoot)...); err != nil {
 			return err
 		}
 		if err := exec.Run(ctx, "mount", b.mappedCryptRoot, b.mntPoint); err != nil {
@@ -323,7 +330,7 @@ func (b *builder) mountImg(ctx context.Context) error {
 		}
 	} else {
 		logrus.Infof("creating raw image file system")
-		if err := exec.Run(ctx, "mkfs.ext4", b.rootPart); err != nil {
+		if err := exec.Run(ctx, "mkfs.ext4", append(mkfsExt4Opts, b.rootPart)...); err != nil {
 			return err
 		}
 		if err := exec.Run(ctx, "mount", b.rootPart, b.mntPoint); err != nil {
@@ -339,7 +346,7 @@ func (b *builder) mountImg(ctx context.Context) error {
 	if b.bootFS.IsFat() {
 		err = exec.Run(ctx, "mkfs.fat", "-F32", b.bootPart)
 	} else {
-		err = exec.Run(ctx, "mkfs.ext4", b.bootPart)
+		err = exec.Run(ctx, "mkfs.ext4", append(mkfsExt4Opts, b.bootPart)...)
 	}
 	if err != nil {
 		return err

--- a/builder.go
+++ b/builder.go
@@ -284,7 +284,7 @@ func (b *builder) mountImg(ctx context.Context) error {
 	r := ctx.Value("release").(OSRelease)
 	if r.ID == ReleaseUbuntu {
 		if strings.HasPrefix(r.VersionID, "12.") {
-			mkfsExt4Opts = append(mkfsExt4Opts, "-O", "^has_journal")
+			mkfsExt4Opts = append(mkfsExt4Opts, "-O", "^has_journal,^metadata_csum")
 		}
 	}
 	logrus.Infof("mounting raw image")

--- a/convert.go
+++ b/convert.go
@@ -45,7 +45,7 @@ func Convert(ctx context.Context, img string, opts ...ConvertOption) error {
 	if err != nil {
 		return err
 	}
-
+	ctx = context.WithValue(ctx, "release", r)
 	if o.luksPassword != "" && !r.SupportsLUKS() {
 		return fmt.Errorf("luks is not supported for %s %s", r.Name, r.Version)
 	}

--- a/dockerfile.go
+++ b/dockerfile.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"text/template"
 
 	"github.com/sirupsen/logrus"
@@ -26,6 +27,9 @@ import (
 
 //go:embed templates/ubuntu.Dockerfile
 var ubuntuDockerfile string
+
+//go:embed templates/ubuntu12.Dockerfile
+var ubuntu12Dockerfile string
 
 //go:embed templates/debian.Dockerfile
 var debianDockerfile string
@@ -37,10 +41,11 @@ var alpineDockerfile string
 var centOSDockerfile string
 
 var (
-	ubuntuDockerfileTemplate = template.Must(template.New("ubuntu.Dockerfile").Funcs(tplFuncs).Parse(ubuntuDockerfile))
-	debianDockerfileTemplate = template.Must(template.New("debian.Dockerfile").Funcs(tplFuncs).Parse(debianDockerfile))
-	alpineDockerfileTemplate = template.Must(template.New("alpine.Dockerfile").Funcs(tplFuncs).Parse(alpineDockerfile))
-	centOSDockerfileTemplate = template.Must(template.New("centos.Dockerfile").Funcs(tplFuncs).Parse(centOSDockerfile))
+	ubuntuDockerfileTemplate   = template.Must(template.New("ubuntu.Dockerfile").Funcs(tplFuncs).Parse(ubuntuDockerfile))
+	ubuntu12DockerfileTemplate = template.Must(template.New("ubuntu12.Dockerfile").Funcs(tplFuncs).Parse(ubuntu12Dockerfile))
+	debianDockerfileTemplate   = template.Must(template.New("debian.Dockerfile").Funcs(tplFuncs).Parse(debianDockerfile))
+	alpineDockerfileTemplate   = template.Must(template.New("alpine.Dockerfile").Funcs(tplFuncs).Parse(alpineDockerfile))
+	centOSDockerfileTemplate   = template.Must(template.New("centos.Dockerfile").Funcs(tplFuncs).Parse(centOSDockerfile))
 )
 
 type NetworkManager string
@@ -90,7 +95,11 @@ func NewDockerfile(release OSRelease, img, password string, networkManager Netwo
 		d.tmpl = debianDockerfileTemplate
 		net = NetworkManagerIfupdown2
 	case ReleaseUbuntu:
-		d.tmpl = ubuntuDockerfileTemplate
+		if strings.HasPrefix(release.VersionID, "12.") {
+			d.tmpl = ubuntu12DockerfileTemplate
+		} else {
+			d.tmpl = ubuntuDockerfileTemplate
+		}
 		if release.VersionID < "18.04" {
 			net = NetworkManagerIfupdown2
 		} else {

--- a/templates/ubuntu12.Dockerfile
+++ b/templates/ubuntu12.Dockerfile
@@ -1,0 +1,67 @@
+FROM {{ .Image }}
+
+USER root
+
+RUN ARCH="$([ "$(uname -m)" = "x86_64" ] && echo amd64 || echo arm64)"; \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+  linux-image-virtual \
+  initramfs-tools \
+{{- if .Grub }}
+  grub-common \
+  grub2-common \
+{{- end }}
+{{- if .GrubBIOS }}
+  grub-pc-bin \
+{{- end }}
+{{- if .GrubEFI }}
+  grub-efi-${ARCH}-bin \
+{{- end }}
+  dbus \
+  isc-dhcp-client \
+  iputils-ping && \
+  find /boot -type l -exec rm {} \;
+
+{{ if gt .Release.VersionID "16.04" }}
+RUN systemctl preset-all
+{{ end }}
+
+{{ if .Password }}RUN echo "root:{{ .Password }}" | chpasswd {{ end }}
+
+{{ if eq .NetworkManager "netplan" }}
+RUN apt install -y netplan.io
+RUN mkdir -p /etc/netplan && printf '\
+network:\n\
+  version: 2\n\
+  renderer: networkd\n\
+  ethernets:\n\
+    eth0:\n\
+      dhcp4: true\n\
+      dhcp-identifier: mac\n\
+      nameservers:\n\
+        addresses:\n\
+        - 8.8.8.8\n\
+        - 8.8.4.4\n\
+' > /etc/netplan/00-netcfg.yaml
+{{ else if eq .NetworkManager "ifupdown"}}
+RUN if [ -z "$(apt-cache madison ifupdown-ng 2> /dev/nul)" ]; then apt-get install -y ifupdown; else apt-get install -y ifupdown-ng; fi
+RUN mkdir -p /etc/network && printf '\
+auto eth0\n\
+allow-hotplug eth0\n\
+iface eth0 inet dhcp\n\
+' > /etc/network/interfaces
+{{ end }}
+
+{{- if .Luks }}
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cryptsetup-initramfs && \
+    update-initramfs -u -v
+{{- end }}
+
+# needs to be after update-initramfs
+{{- if not .Grub }}
+RUN mv $(find /boot -name 'vmlinuz-*') /boot/vmlinuz && \
+      mv $(find /boot -name 'initrd.img-*') /boot/initrd.img
+{{- end }}
+
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/templates/ubuntu12.Dockerfile
+++ b/templates/ubuntu12.Dockerfile
@@ -2,6 +2,12 @@ FROM {{ .Image }}
 
 USER root
 
+# restore initctl
+RUN rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl
+
+# setup ttyS0
+RUN cp /etc/init/tty1.conf /etc/init/ttyS0.conf && sed -i s/tty1/ttyS0/g /etc/init/ttyS0.conf
+
 RUN ARCH="$([ "$(uname -m)" = "x86_64" ] && echo amd64 || echo arm64)"; \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \


### PR DESCRIPTION
to fix #55 

What this commit did:

1. mkfs.ext4 -O ^has_journal,^metadata_csum
2. restore initctl
3. setup ttyS0
4. remove packages ubuntu12 does not support

Testcase: 

```
$ cat Dockerfile                                                                                                                                     
FROM ubuntu:12.04

# apt sources
RUN sed -i 's/archive/old-releases/g' /etc/apt/sources.list

$ docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --privileged -v $(pwd):/d2vm -w /d2vm ssst0n3/d2vm:v0.2.1-dev build -f Dockerfile . -v

$ cp disk0.qcow2 vm.qcow2
$ qemu-system-x86_64 -hda vm.qcow2 --enable-kvm -nographic
...
Ubuntu 12.04.5 LTS localhost.localdomain ttyS0

localhost login: 
```