### PR TITLE
when multiple kernels and initrds exist, use the latest

### DIFF
--- a/templates/debian.Dockerfile
+++ b/templates/debian.Dockerfile
@@ -71,8 +71,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cr
 
 # needs to be after update-initramfs
 {{- if not .Grub }}
-RUN mv $(find /boot -name 'vmlinuz-*') /boot/vmlinuz && \
-      mv $(find /boot -name 'initrd.img-*') /boot/initrd.img
+RUN mv $(ls -t /boot/vmlinuz-* | head -n 1) /boot/vmlinuz && \
+      mv $(ls -t /boot/initrd.img-* | head -n 1) /boot/initrd.img
 {{- end }}
 
 RUN apt-get clean && \

--- a/templates/ubuntu.Dockerfile
+++ b/templates/ubuntu.Dockerfile
@@ -62,8 +62,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cr
 
 # needs to be after update-initramfs
 {{- if not .Grub }}
-RUN mv $(find /boot -name 'vmlinuz-*') /boot/vmlinuz && \
-      mv $(find /boot -name 'initrd.img-*') /boot/initrd.img
+RUN mv $(ls -t /boot/vmlinuz-* | head -n 1) /boot/vmlinuz && \
+      mv $(ls -t /boot/initrd.img-* | head -n 1) /boot/initrd.img
 {{- end }}
 
 RUN apt-get clean && \


### PR DESCRIPTION
When multiple kernels or initrds exist the process fails with the error
```
Step 7/8 : RUN mv $(find /boot -name 'vmlinuz-*') /boot/vmlinuz &&       mv $(find /boot -name 'initrd.img-*') /boot/initrd.img
 ---> Running in 6de2cb0b8003
mv: target '/boot/initrd.img' is not a directory
```

This is a quick fix to take the latest of each. 