### PR TITLE
Skip disk conversion when format is raw

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -469,6 +469,9 @@ func (b *builder) installBootloader(ctx context.Context) error {
 
 func (b *builder) convert2Img(ctx context.Context) error {
 	logrus.Infof("converting to %s", b.format)
+	if b.format == "raw" {
+		return MoveFile(b.diskRaw, b.diskOut)
+	}
 	return exec.Run(ctx, "qemu-img", "convert", b.diskRaw, "-O", b.format, b.diskOut)
 }
 


### PR DESCRIPTION
This skips the `convert2Img` step in favor of a rename when targetting a raw format. This saves a bit of disk space, but also works around an issue when cross compiling in rosetta on mac hosts where the qemu-convert command triggers the error "Unimplemented syscall number 282"