### PR TITLE
fix: ensure fs error is checked

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -43,7 +43,7 @@ func (f BootFS) IsSupported() bool {
 
 func (f BootFS) Validate() error {
 	if !f.IsSupported() {
-		fmt.Errorf("invalid boot filesystem: %s valid filesystems are: fat32, ext4", f)
+		return fmt.Errorf("invalid boot filesystem: %s valid filesystems are: fat32, ext4", f)
 	}
 	return nil
 }


### PR DESCRIPTION
Right now an error is created, but its value is not returned. 