### PR TITLE
chore(ci): call linter in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-tests-
 
+    - name: Run linter
+      run: make vet
+
     - name: Run tests
       run: git --no-pager diff --exit-code HEAD~1 HEAD **/**.go templates/ || make tests
 


### PR DESCRIPTION
This adds the already existing vet target in the makefile to the list of operation to be called in CI. This should help ensure that small escapes like missing returns for errors doesn't happen.